### PR TITLE
Move `aws-sdk` to devDependecies

### DIFF
--- a/package.json
+++ b/package.json
@@ -35,9 +35,7 @@
     },
     "devDependencies": {
         "chai": "^3.2.0",
+        "aws-sdk": "^2.3.19",
         "mocha": "^2.2.5"
-    },
-    "dependencies": {
-        "aws-sdk": "^2.3.19"
     }
 }


### PR DESCRIPTION
So it won't get installed into `node_modules` and deployed to AWS.