### PR TITLE
Allow LOCAL_DDB_PORT to override port

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,7 +1,9 @@
+var PORT = process.env.LOCAL_DDB_PORT || '8000';
+
 var AWS = require('aws-sdk'),
     options = {
         region: "localhost",
-        endpoint: "http://localhost:8000"
+        endpoint: "http://localhost:"+PORT
     };
 
 var isOffline = function () {


### PR DESCRIPTION
Implements #13 

This allows something like:

```
  environment:
    LOCAL_DDB_PORT: ${self:custom.dynamodb.start.port, 8000}
```

in `serverless.yml`.